### PR TITLE
Add missing operations to TreeMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["croaring", "croaring-sys"]
+resolver = "2"

--- a/croaring-sys/build.rs
+++ b/croaring-sys/build.rs
@@ -9,7 +9,7 @@ fn main() {
     build.file("CRoaring/roaring.c");
 
     if let Ok(target_arch) = env::var("ROARING_ARCH") {
-        build.flag_if_supported(&format!("-march={}", target_arch));
+        build.flag_if_supported(&format!("-march={target_arch}"));
     }
 
     build.flag_if_supported("-Wno-unused-function");

--- a/croaring/src/bitmap/iter.rs
+++ b/croaring/src/bitmap/iter.rs
@@ -172,6 +172,7 @@ impl Bitmap {
     /// ```
     #[inline]
     #[doc(alias = "roaring_init_iterator")]
+    #[must_use]
     pub fn iter(&self) -> BitmapIterator {
         BitmapIterator::new(self)
     }

--- a/croaring/src/bitmap/mod.rs
+++ b/croaring/src/bitmap/mod.rs
@@ -1,6 +1,6 @@
-//! Rust wrapper for CRoaring (a C/C++ implementation at https://github.com/RoaringBitmap/CRoaring)
+//! Rust wrapper for `CRoaring` (a C/C++ implementation at <https://github.com/RoaringBitmap/CRoaring>)
 //!
-//! The original Java version can be found at https://github.com/RoaringBitmap/RoaringBitmap
+//! The original Java version can be found at <https://github.com/RoaringBitmap/RoaringBitmap>
 //! # Example
 //!
 //! ```rust

--- a/croaring/src/bitmap/ops.rs
+++ b/croaring/src/bitmap/ops.rs
@@ -48,6 +48,8 @@ impl PartialEq<Bitmap> for BitmapView<'_> {
     }
 }
 
+impl Eq for Bitmap {}
+
 impl Clone for Bitmap {
     /// Create a copy of a Bitmap
     /// # Examples

--- a/croaring/src/bitmap/serialization.rs
+++ b/croaring/src/bitmap/serialization.rs
@@ -16,7 +16,7 @@ pub trait ViewDeserializer {
 }
 
 /// The `Portable` format is meant to be compatible with other roaring bitmap libraries, such as Go or Java.
-/// It's defined here: https://github.com/RoaringBitmap/RoaringFormatSpec
+/// It's defined here: <https://github.com/RoaringBitmap/RoaringFormatSpec>
 pub enum Portable {}
 
 impl Serializer for Portable {
@@ -56,14 +56,14 @@ impl Deserializer for Portable {
     fn try_deserialize(buffer: &[u8]) -> Option<Bitmap> {
         unsafe {
             let bitmap = ffi::roaring_bitmap_portable_deserialize_safe(
-                buffer.as_ptr() as *const c_char,
+                buffer.as_ptr().cast::<c_char>(),
                 buffer.len(),
             );
 
-            if !bitmap.is_null() {
-                Some(Bitmap::take_heap(bitmap))
-            } else {
+            if bitmap.is_null() {
                 None
+            } else {
+                Some(Bitmap::take_heap(bitmap))
             }
         }
     }
@@ -81,7 +81,7 @@ impl ViewDeserializer for Portable {
     /// * Using this function (or the returned bitmap in any way) may execute unaligned memory accesses
     ///
     #[doc(alias = "roaring_bitmap_portable_deserialize_frozen")]
-    unsafe fn deserialize_view<'a>(data: &'a [u8]) -> BitmapView {
+    unsafe fn deserialize_view(data: &[u8]) -> BitmapView<'_> {
         // portable_deserialize_size does some amount of checks, and returns zero if data cannot be valid
         debug_assert_ne!(
             ffi::roaring_bitmap_portable_deserialize_size(data.as_ptr().cast(), data.len()),
@@ -134,14 +134,14 @@ impl Deserializer for Native {
     fn try_deserialize(buffer: &[u8]) -> Option<Bitmap> {
         unsafe {
             let bitmap = ffi::roaring_bitmap_deserialize_safe(
-                buffer.as_ptr() as *const c_void,
+                buffer.as_ptr().cast::<c_void>(),
                 buffer.len(),
             );
 
-            if !bitmap.is_null() {
-                Some(Bitmap::take_heap(bitmap))
-            } else {
+            if bitmap.is_null() {
                 None
+            } else {
+                Some(Bitmap::take_heap(bitmap))
             }
         }
     }
@@ -206,7 +206,7 @@ impl ViewDeserializer for Frozen {
     /// * data.len() must be equal exactly to the size of the frozen bitmap.
     ///
     /// See [`BitmapView::deserialize`] for examples.
-    unsafe fn deserialize_view<'a>(data: &'a [u8]) -> BitmapView {
+    unsafe fn deserialize_view(data: &[u8]) -> BitmapView<'_> {
         const REQUIRED_ALIGNMENT: usize = 32;
         assert_eq!(data.as_ptr() as usize % REQUIRED_ALIGNMENT, 0);
 

--- a/croaring/src/bitmap/view.rs
+++ b/croaring/src/bitmap/view.rs
@@ -45,6 +45,8 @@ impl<'a> BitmapView<'a> {
         }
     }
 
+    /// Create a bitmap view of a slice of data without copying
+    ///
     /// # Examples
     ///
     /// ```
@@ -55,6 +57,11 @@ impl<'a> BitmapView<'a> {
     /// assert!(view.contains_range(1..=4));
     /// assert_eq!(orig_bitmap, view);
     /// ```
+    ///
+    /// # Safety
+    ///
+    /// The data must be the result of serializing a bitmap with the same serialization format
+    #[must_use]
     pub unsafe fn deserialize<S: ViewDeserializer>(data: &'a [u8]) -> Self {
         S::deserialize_view(data)
     }
@@ -76,6 +83,7 @@ impl<'a> BitmapView<'a> {
     /// assert!(!view.contains(10));
     /// assert!(mutable_bitmap.contains(10));
     /// ```
+    #[must_use]
     pub fn to_bitmap(&self) -> Bitmap {
         (**self).clone()
     }
@@ -86,6 +94,7 @@ impl<'a> Deref for BitmapView<'a> {
 
     fn deref(&self) -> &Self::Target {
         const _: () = assert!(mem::size_of::<Bitmap>() == mem::size_of::<BitmapView>());
+        const _: () = assert!(mem::align_of::<Bitmap>() == mem::align_of::<BitmapView>());
         // SAFETY:
         //   Bitmap and BitmapView are repr(transparent), and both only wrap a roaring_bitmap_t
         //   Bitmap provides no features with a shared reference which modifies the underlying bitmap

--- a/croaring/src/bitmap/view.rs
+++ b/croaring/src/bitmap/view.rs
@@ -93,6 +93,14 @@ impl<'a> Deref for BitmapView<'a> {
     }
 }
 
+impl PartialEq for BitmapView<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        Bitmap::eq(self, other)
+    }
+}
+
+impl Eq for BitmapView<'_> {}
+
 impl<'a> Drop for BitmapView<'a> {
     fn drop(&mut self) {
         // Based heavily on the c++ wrapper included in CRoaring

--- a/croaring/src/bitset/imp.rs
+++ b/croaring/src/bitset/imp.rs
@@ -16,6 +16,7 @@ impl Bitset {
 
     /// Access the raw underlying slice
     #[inline]
+    #[must_use]
     pub const fn as_slice(&self) -> &[u64] {
         if self.bitset.arraysize == 0 {
             &[]
@@ -47,6 +48,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_create")]
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             bitset: ffi::bitset_t {
@@ -69,12 +71,14 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_create_with_capacity")]
+    #[must_use]
     pub fn with_size(size: usize) -> Self {
         unsafe { Self::take_heap(ffi::bitset_create_with_capacity(size)) }
     }
 
     /// Capacity in bits
     #[inline]
+    #[must_use]
     pub const fn capacity(&self) -> usize {
         self.bitset.capacity * 64
     }
@@ -109,6 +113,7 @@ impl Bitset {
     /// How many bytes of memory the backend buffer uses
     #[inline]
     #[doc(alias = "bitset_size_in_bytes")]
+    #[must_use]
     pub const fn size_in_bytes(&self) -> usize {
         self.size_in_words() * mem::size_of::<u64>()
     }
@@ -116,6 +121,7 @@ impl Bitset {
     /// How many bits can be accessed
     #[inline]
     #[doc(alias = "bitset_size_in_bits")]
+    #[must_use]
     pub const fn size_in_bits(&self) -> usize {
         self.size_in_bytes() * 8
     }
@@ -123,6 +129,7 @@ impl Bitset {
     /// How many 64-bit words of memory the backend buffer uses
     #[inline]
     #[doc(alias = "bitset_size_in_words")]
+    #[must_use]
     pub const fn size_in_words(&self) -> usize {
         self.bitset.arraysize
     }
@@ -138,13 +145,14 @@ impl Bitset {
     /// bitset.resize_words(1, false);
     /// bitset.resize_words(2, true);
     /// assert_eq!(bitset.iter().collect::<Vec<_>>(), (64..128).collect::<Vec<_>>());
+    /// ```
     pub fn resize_words(&mut self, new_array_size: usize, value: bool) {
         let old_array_size = self.bitset.arraysize;
         let res = unsafe { ffi::bitset_resize(&mut self.bitset, new_array_size, value) };
         assert!(res);
         if new_array_size > old_array_size {
             let new_data_slice = &mut self.as_mut_slice()[old_array_size..];
-            new_data_slice.fill((value as u64) * !0);
+            new_data_slice.fill(u64::from(value) * !0);
         }
     }
 
@@ -221,7 +229,7 @@ impl Bitset {
         }
         let dst = &mut self.as_mut_slice()[array_idx];
         let mask = 1 << (i % 64);
-        let value_bit = (value as u64) << (i % 64);
+        let value_bit = u64::from(value) << (i % 64);
         let mut word = *dst;
         word &= !mask;
         word |= value_bit;
@@ -244,6 +252,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_get")]
+    #[must_use]
     pub const fn get(&self, i: usize) -> bool {
         let array_idx = i / 64;
         if array_idx >= self.bitset.arraysize {
@@ -264,6 +273,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_count")]
+    #[must_use]
     pub fn count(&self) -> usize {
         unsafe { ffi::bitset_count(&self.bitset) }
     }
@@ -281,6 +291,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_minimum")]
+    #[must_use]
     pub fn minimum(&self) -> usize {
         unsafe { ffi::bitset_minimum(&self.bitset) }
     }
@@ -300,6 +311,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_maximum")]
+    #[must_use]
     pub fn maximum(&self) -> usize {
         unsafe { ffi::bitset_maximum(&self.bitset) }
     }
@@ -317,6 +329,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_union_count")]
+    #[must_use]
     pub fn union_count(&self, other: &Self) -> usize {
         // CRoaring uses restrict pointers, so we can't use the same pointer for both
         if ptr::eq(self, other) {
@@ -338,6 +351,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_intersection_count")]
+    #[must_use]
     pub fn intersection_count(&self, other: &Self) -> usize {
         // CRoaring uses restrict pointers, so we can't use the same pointer for both
         if ptr::eq(self, other) {
@@ -368,6 +382,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_disjoint")]
+    #[must_use]
     pub fn is_disjoint(&self, other: &Self) -> bool {
         // CRoaring uses restrict pointers, so we can't use the same pointer for both
         if ptr::eq(self, other) {
@@ -389,6 +404,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_intersect")]
+    #[must_use]
     pub fn has_intersect(&self, other: &Self) -> bool {
         // CRoaring uses restrict pointers, so we can't use the same pointer for both
         if ptr::eq(self, other) {
@@ -410,6 +426,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_contains_all")]
+    #[must_use]
     pub fn is_superset(&self, other: &Self) -> bool {
         // CRoaring uses restrict pointers, so we can't use the same pointer for both
         if ptr::eq(self, other) {
@@ -431,6 +448,7 @@ impl Bitset {
     /// ```
     #[inline]
     #[doc(alias = "bitset_difference_count")]
+    #[must_use]
     pub fn difference_count(&self, other: &Self) -> usize {
         // CRoaring uses restrict pointers, so we can't use the same pointer for both
         if ptr::eq(self, other) {
@@ -453,6 +471,7 @@ impl Bitset {
     #[inline]
     #[doc(alias = "bitset_symmetric_difference_count")]
     #[doc(alias = "xor_count")]
+    #[must_use]
     pub fn symmetric_difference_count(&self, other: &Self) -> usize {
         // CRoaring uses restrict pointers, so we can't use the same pointer for both
         if ptr::eq(self, other) {
@@ -461,18 +480,20 @@ impl Bitset {
         unsafe { ffi::bitset_symmetric_difference_count(&self.bitset, &other.bitset) }
     }
 
-    /// Expose the raw CRoaring bitset
+    /// Expose the raw `CRoaring` bitset
     ///
-    /// This allows calling raw CRoaring functions on the bitset.
+    /// This allows calling raw `CRoaring` functions on the bitset.
     #[inline]
+    #[must_use]
     pub fn as_raw(&self) -> &ffi::bitset_t {
         &self.bitset
     }
 
-    /// Expose the raw CRoaring bitset mutibly
+    /// Expose the raw `CRoaring` bitset mutably
     ///
-    /// This allows calling raw CRoaring functions on the bitset.
+    /// This allows calling raw `CRoaring` functions on the bitset.
     #[inline]
+    #[must_use]
     pub fn as_raw_mut(&mut self) -> &mut ffi::bitset_t {
         &mut self.bitset
     }

--- a/croaring/src/bitset/iter.rs
+++ b/croaring/src/bitset/iter.rs
@@ -70,6 +70,7 @@ impl<'a> IntoIterator for &'a Bitset {
 impl Bitset {
     /// Returns an iterator over the set bits in the bitset
     #[inline]
+    #[must_use]
     pub const fn iter(&self) -> BitsetIterator<'_> {
         BitsetIterator {
             bitset: self,

--- a/croaring/src/bitset/mod.rs
+++ b/croaring/src/bitset/mod.rs
@@ -5,6 +5,7 @@ mod iter;
 mod ops;
 
 /// A dense bitset
+#[repr(transparent)]
 pub struct Bitset {
     bitset: ffi::bitset_t,
 }

--- a/croaring/src/bitset/ops.rs
+++ b/croaring/src/bitset/ops.rs
@@ -51,8 +51,8 @@ impl ops::BitOrAssign<&Bitset> for Bitset {
     #[inline]
     #[doc(alias = "bitset_inplace_union")]
     fn bitor_assign(&mut self, rhs: &Bitset) {
-        let res = unsafe { ffi::bitset_inplace_union(&mut self.bitset, &rhs.bitset) };
-        assert!(res);
+        let result = unsafe { ffi::bitset_inplace_union(&mut self.bitset, &rhs.bitset) };
+        assert!(result);
     }
 }
 

--- a/croaring/src/treemap/imp.rs
+++ b/croaring/src/treemap/imp.rs
@@ -575,7 +575,7 @@ impl Treemap {
     }
 
     /// Returns the smallest value in the set.
-    /// Returns std::u64::MAX if the set is empty.
+    /// Returns [`u64::MAX`] if the set is empty.
     ///
     /// # Examples
     ///
@@ -591,11 +591,11 @@ impl Treemap {
     /// assert_eq!(treemap.minimum(), Some(120));
     /// assert_eq!(empty_treemap.minimum(), None);
     /// ```
+    #[must_use]
     pub fn minimum(&self) -> Option<u64> {
         self.map
             .iter()
-            .filter_map(|(&k, bitmap)| bitmap.minimum().map(|low| util::join(k, low)))
-            .next()
+            .find_map(|(&k, bitmap)| bitmap.minimum().map(|low| util::join(k, low)))
     }
 
     /// Returns the greatest value in the set.
@@ -615,12 +615,12 @@ impl Treemap {
     /// assert_eq!(treemap.maximum(), Some(1000));
     /// assert_eq!(empty_treemap.maximum(), None);
     /// ```
+    #[must_use]
     pub fn maximum(&self) -> Option<u64> {
         self.map
             .iter()
             .rev()
-            .filter_map(|(&k, bitmap)| bitmap.maximum().map(|low| util::join(k, low)))
-            .next()
+            .find_map(|(&k, bitmap)| bitmap.maximum().map(|low| util::join(k, low)))
     }
 
     /// And computes the intersection between two treemaps and returns the
@@ -644,6 +644,7 @@ impl Treemap {
     /// assert!(treemap3.contains(u64::MAX));
     /// assert!(!treemap3.contains(2));
     /// ```
+    #[must_use]
     pub fn and(&self, other: &Self) -> Self {
         let mut treemap = Treemap::create();
 
@@ -739,6 +740,7 @@ impl Treemap {
     /// assert!(treemap3.contains(u64::MAX));
     /// assert!(treemap3.contains(25));
     /// ```
+    #[must_use]
     pub fn or(&self, other: &Self) -> Self {
         let mut treemap = self.clone();
 
@@ -826,6 +828,7 @@ impl Treemap {
     /// assert!(!treemap3.contains(25));
     /// assert!(treemap3.contains(35));
     /// ```
+    #[must_use]
     pub fn xor(&self, other: &Self) -> Self {
         let mut treemap = self.clone();
 
@@ -918,6 +921,7 @@ impl Treemap {
     /// assert!(!treemap3.contains(u64::MAX));
     /// assert!(!treemap3.contains(35));
     /// ```
+    #[must_use]
     pub fn andnot(&self, other: &Self) -> Self {
         let mut treemap = Treemap::create();
 
@@ -988,6 +992,7 @@ impl Treemap {
     ///
     /// assert_eq!(treemap.to_vec(), [15, 25, u64::MAX]);
     /// ```
+    #[must_use]
     pub fn to_vec(&self) -> Vec<u64> {
         let treemap_size: usize = self.cardinality().try_into().unwrap();
 
@@ -1001,7 +1006,7 @@ impl Treemap {
                 if n == 0 {
                     break;
                 }
-                result.extend(buffer[..n].iter().map(|&bit| util::join(key, bit)))
+                result.extend(buffer[..n].iter().map(|&bit| util::join(key, bit)));
             }
         }
 
@@ -1032,6 +1037,7 @@ impl Treemap {
     /// assert!(!treemap.contains(3));
     /// assert_eq!(treemap, treemap2);
     /// ```
+    #[must_use]
     pub fn of(elements: &[u64]) -> Self {
         let mut treemap = Treemap::create();
 

--- a/croaring/src/treemap/imp.rs
+++ b/croaring/src/treemap/imp.rs
@@ -22,6 +22,26 @@ impl Treemap {
         }
     }
 
+    /// Creates a `Treemap` with the contents of a `Bitmap`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use croaring::Treemap;
+    /// use croaring::Bitmap;
+    ///
+    /// let bitmap = Bitmap::of(&[1, 2, 3]);
+    /// let treemap = Treemap::from_bitmap(bitmap);
+    /// assert_eq!(treemap.cardinality(), 3);
+    /// ```
+    pub fn from_bitmap(bitmap: Bitmap) -> Self {
+        let mut map = BTreeMap::new();
+        map.insert(0, bitmap);
+        Treemap { map }
+    }
+
+    /// Add the integer element to the bitmap
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -38,7 +58,24 @@ impl Treemap {
     /// ```
     pub fn add(&mut self, value: u64) {
         let (hi, lo) = util::split(value);
-        self.map.entry(hi).or_insert_with(Bitmap::create).add(lo)
+        self.get_or_create(hi).add(lo);
+    }
+
+    /// Add the integer element to the bitmap. Returns true if the value was
+    /// added, false if the value was already in the bitmap.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::Treemap;
+    ///
+    /// let mut bitmap = Treemap::create();
+    /// assert!(bitmap.add_checked(1));
+    /// assert!(!bitmap.add_checked(1));
+    /// ```
+    pub fn add_checked(&mut self, value: u64) -> bool {
+        let (hi, lo) = util::split(value);
+        self.get_or_create(hi).add_checked(lo)
     }
 
     /// Add all values in range
@@ -102,7 +139,7 @@ impl Treemap {
 
         // Step 1: Partially fill the first bitmap
         {
-            let bitmap = self.map.entry(start_high).or_insert_with(Bitmap::create);
+            let bitmap = self.get_or_create(start_high);
             bitmap.add_range(start_low..=u32::MAX);
         }
         // Step 2: Fill intermediate bitmaps completely
@@ -112,7 +149,7 @@ impl Treemap {
         }
         // Step 3: Partially fill the last bitmap
         {
-            let bitmap = self.map.entry(end_high).or_insert_with(Bitmap::create);
+            let bitmap = self.get_or_create(end_high);
             bitmap.add_range(0..=end_low);
         }
     }
@@ -150,6 +187,144 @@ impl Treemap {
         self.map.values().all(Bitmap::is_empty)
     }
 
+    /// Returns true if the Treemap is full.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::Treemap;
+    ///
+    /// let mut treemap = Treemap::create();
+    /// assert!(!treemap.is_full());
+    /// ```
+    pub fn is_full(&self) -> bool {
+        // only bother to check if map is fully saturated
+        if self.map.len() != usize::try_from(u32::MAX).unwrap() + 1 {
+            return false;
+        }
+        self.map
+            .values()
+            .all(|bitmap| bitmap.cardinality() == u64::from(u32::MAX) + 1)
+    }
+
+    /// Return true if all the elements of Self are in &other.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::Treemap;
+    ///
+    /// let bitmap1: Treemap = (5..10).collect();
+    /// let bitmap2: Treemap = (5..8).collect();
+    /// let bitmap3: Treemap = (5..10).collect();
+    /// let bitmap4: Treemap = (9..11).collect();
+    ///
+    /// assert!(bitmap2.is_subset(&bitmap1));
+    /// assert!(bitmap3.is_subset(&bitmap1));
+    /// assert!(!bitmap4.is_subset(&bitmap1));
+    /// ```
+    pub fn is_subset(&self, other: &Treemap) -> bool {
+        self.map.iter().all(|(key, lhs)| {
+            lhs.is_empty() || other.map.get(key).map_or(false, |rhs| lhs.is_subset(rhs))
+        })
+    }
+
+    /// Returns true if this bitmap is a strict subset of `other`
+    pub fn is_strict_subset(&self, other: &Treemap) -> bool {
+        self.is_subset(other) && self.cardinality() != other.cardinality()
+    }
+
+    /// Negate the bits in the given range, any bit set in the range is cleared, and any bit cleared
+    ///
+    /// Areas outside the interval are unchanged
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::Treemap;
+    ///
+    /// let mut treemap = Treemap::create();
+    /// treemap.add_range(1..5);
+    /// treemap.flip(2..10);
+    /// assert_eq!(treemap.cardinality(), 4);
+    /// assert_eq!(treemap.iter().collect::<Vec<_>>(), vec![1, 5, 6, 7, 8, 9]);
+    /// ```
+    pub fn flip<R: RangeBounds<u64>>(&mut self, range: R) {
+        let (start, end) = range_to_inclusive(range);
+        self.flip_inclusive(start, end);
+    }
+
+    fn flip_inclusive(&mut self, start: u64, end: u64) {
+        if start > end {
+            return;
+        }
+        let (start_high, start_low) = util::split(start);
+        let (end_high, end_low) = util::split(end);
+
+        if start_high == end_high {
+            match self.map.entry(start_high) {
+                Entry::Occupied(mut entry) => {
+                    entry.get_mut().flip_inplace(start_low..=end_low);
+                    if entry.get().is_empty() {
+                        entry.remove();
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(Bitmap::from_range(start_low..=end_low));
+                }
+            }
+            return;
+        }
+
+        // Because start and end don't land on the same inner bitmap,
+        // we need to do this in multiple steps:
+        // 1. Partially flip the first bitmap with values from the closed
+        //    interval [start_low, uint32_max]
+        // 2. Flip intermediate bitmaps completely: [0, uint32_max]
+        // 3. Partially flip the last bitmap with values from the closed
+
+        // Step 1: Partially flip the first bitmap
+        match self.map.entry(start_high) {
+            Entry::Vacant(e) => {
+                e.insert(Bitmap::from_range(start_low..=u32::MAX));
+            }
+            Entry::Occupied(mut e) => {
+                e.get_mut().flip_inplace(start_low..=u32::MAX);
+                if e.get().is_empty() {
+                    e.remove();
+                }
+            }
+        }
+
+        // Step 2: Flip intermediate bitmaps completely
+        for i in start_high + 1..end_high {
+            match self.map.entry(i) {
+                Entry::Vacant(e) => {
+                    e.insert(Bitmap::from_range(..));
+                }
+                Entry::Occupied(mut e) => {
+                    e.get_mut().flip_inplace(..);
+                    if e.get().is_empty() {
+                        e.remove();
+                    }
+                }
+            }
+        }
+
+        // Step 3: Partially flip the last bitmap
+        match self.map.entry(end_high) {
+            Entry::Vacant(e) => {
+                e.insert(Bitmap::from_range(..=end_low));
+            }
+            Entry::Occupied(mut e) => {
+                e.get_mut().flip_inplace(..=end_low);
+                if e.get().is_empty() {
+                    e.remove();
+                }
+            }
+        }
+    }
+
     /// Empties the Treemap
     ///
     /// # Examples
@@ -170,7 +345,7 @@ impl Treemap {
     /// assert!(treemap.is_empty());
     /// ```
     pub fn clear(&mut self) {
-        self.map.iter_mut().for_each(|(_, bitmap)| bitmap.clear())
+        self.map.clear();
     }
 
     /// Remove element from the Treemap
@@ -198,6 +373,184 @@ impl Treemap {
                 }
             }
         }
+    }
+
+    /// Remove element from the Treemap, returning if a value was removed
+    ///
+    /// Returns true if the element was removed, false if it was not present
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::Treemap;
+    ///
+    /// let mut treemap = Treemap::create();
+    /// treemap.add(u64::MAX);
+    /// assert!(treemap.remove_checked(u64::MAX));
+    /// assert!(!treemap.remove_checked(u64::MAX));
+    /// ```
+    pub fn remove_checked(&mut self, element: u64) -> bool {
+        let (hi, lo) = util::split(element);
+        match self.map.entry(hi) {
+            Entry::Vacant(_) => false,
+            Entry::Occupied(mut bitmap) => {
+                let removed = bitmap.get_mut().remove_checked(lo);
+                if bitmap.get().is_empty() {
+                    bitmap.remove();
+                }
+                removed
+            }
+        }
+    }
+
+    /// Remove all values in range
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::Treemap;
+    ///
+    /// let mut treemap = Treemap::create();
+    /// treemap.add_range(0..=10);
+    /// treemap.remove_range(5..=15);
+    /// assert_eq!(treemap.cardinality(), 5);
+    /// ```
+    pub fn remove_range<R: RangeBounds<u64>>(&mut self, range: R) {
+        let (start, end) = range_to_inclusive(range);
+        self.remove_range_inclusive(start, end);
+    }
+
+    fn remove_range_inclusive(&mut self, start: u64, end: u64) {
+        if start > end {
+            return;
+        }
+        let (start_high, start_low) = util::split(start);
+        let (end_high, end_low) = util::split(end);
+
+        if start_high == end_high {
+            if let Entry::Occupied(mut e) = self.map.entry(start_high) {
+                let bitmap = e.get_mut();
+                bitmap.remove_range(start_low..=end_low);
+                if bitmap.is_empty() {
+                    e.remove();
+                }
+            }
+            return;
+        }
+
+        let mut iter = self.map.range_mut(start_high..=end_high);
+        let mut keys_to_remove = Vec::new();
+        // Step 1: Remove first partial range if bitmap exists
+        if let Some((&first_high, first_bitmap)) = iter.next() {
+            if first_high == start_high {
+                first_bitmap.remove_range(start_low..=u32::MAX);
+                if first_bitmap.is_empty() {
+                    keys_to_remove.push(first_high);
+                }
+            } else {
+                keys_to_remove.push(first_high);
+            }
+        }
+        // Step 2: Remove the final partial range if bitmap exists
+        if let Some((&last_high, last_bitmap)) = iter.next_back() {
+            if last_high == end_high {
+                last_bitmap.remove_range(0..=end_low);
+                if last_bitmap.is_empty() {
+                    keys_to_remove.push(last_high);
+                }
+            } else {
+                keys_to_remove.push(last_high);
+            }
+        }
+
+        // Step 3: Remove all full ranges
+        // Unfortunately, there's no way to remove a range from a BTreeMap, so
+        // we have to build a list of keys to remove and then remove them individually
+        keys_to_remove.extend(iter.map(|(&k, _)| k));
+
+        for key in &keys_to_remove {
+            self.map.remove(key);
+        }
+    }
+
+    /// Reallocate memory to shrink the memory usage
+    pub fn shrink_to_fit(&mut self) {
+        for bitmap in self.map.values_mut() {
+            _ = bitmap.shrink_to_fit();
+        }
+    }
+
+    /// Selects the value at index `rank` in the bitmap
+    ///
+    /// The smallest value is at index 0. If 'rank' < cardinality(),
+    /// returns Some, otherwise, returns None
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::Treemap;
+    ///
+    /// let mut treemap = Treemap::create();
+    /// treemap.add_range(10..=20);
+    /// assert_eq!(treemap.select(0), Some(10));
+    /// assert_eq!(treemap.select(10), Some(20));
+    /// assert_eq!(treemap.select(11), None);
+    /// ```
+    pub fn select(&self, mut rank: u64) -> Option<u64> {
+        for (&key, bitmap) in &self.map {
+            let sub_cardinality = bitmap.cardinality();
+            if rank < sub_cardinality {
+                // rank < sub_cadinality, and sub_cardinality is <= 2^32
+                // so rank < 2^32
+                let rank = u32::try_from(rank).unwrap();
+                let low_bytes = bitmap
+                    .select(rank)
+                    .expect("select failed despite rank < cardinailty()");
+                return Some(util::join(key, low_bytes));
+            }
+            rank -= sub_cardinality;
+        }
+        None
+    }
+
+    /// Returns the number of elements that are smaller or equal to `value`
+    pub fn rank(&self, value: u64) -> u64 {
+        let (hi, lo) = util::split(value);
+        let mut rank = 0;
+        let mut range = self.map.range(..=hi);
+        if let Some((&key, bitmap)) = range.next_back() {
+            rank += if key == hi {
+                bitmap.rank(lo)
+            } else {
+                bitmap.cardinality()
+            };
+        }
+        for (_, bitmap) in range {
+            rank += bitmap.cardinality();
+        }
+        rank
+    }
+
+    /// Returns the index of `value` in the set (zero based index)
+    ///
+    /// If the set doesn't contain `value`, return None
+    ///
+    /// The difference with the `rank` method is that this method will return
+    /// None if the value is not in the set, whereas `rank` will always return a value
+    #[doc(alias = "get_index")]
+    pub fn position(&self, value: u64) -> Option<u64> {
+        let (hi, lo) = util::split(value);
+        let mut range = self.map.range(..=hi);
+        let mut index = u64::from(
+            range
+                .next_back()
+                .filter(|(&key, _)| key == hi)
+                .and_then(|(_, bitmap)| bitmap.position(lo))?,
+        );
+        for (_, bitmap) in range {
+            index += bitmap.cardinality();
+        }
+        Some(index)
     }
 
     /// Returns the number of elements contained in the Treemap
@@ -241,8 +594,7 @@ impl Treemap {
     pub fn minimum(&self) -> Option<u64> {
         self.map
             .iter()
-            .filter(|(_, bitmap)| !bitmap.is_empty())
-            .map(|(k, bitmap)| util::join(*k, bitmap.minimum().unwrap()))
+            .filter_map(|(&k, bitmap)| bitmap.minimum().map(|low| util::join(k, low)))
             .next()
     }
 
@@ -267,8 +619,7 @@ impl Treemap {
         self.map
             .iter()
             .rev()
-            .filter(|(_, bitmap)| !bitmap.is_empty())
-            .map(|(k, bitmap)| util::join(*k, bitmap.maximum().unwrap()))
+            .filter_map(|(&k, bitmap)| bitmap.maximum().map(|low| util::join(k, low)))
             .next()
     }
 
@@ -730,58 +1081,8 @@ impl Treemap {
         })
     }
 
-    /// Return true if all the elements of Self are in &other.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use croaring::Treemap;
-    ///
-    /// let bitmap1: Treemap = (5..10).collect();
-    /// let bitmap2: Treemap = (5..8).collect();
-    /// let bitmap3: Treemap = (5..10).collect();
-    /// let bitmap4: Treemap = (9..11).collect();
-    ///
-    /// assert!(bitmap2.is_subset(&bitmap1));
-    /// assert!(bitmap3.is_subset(&bitmap1));
-    /// assert!(!bitmap4.is_subset(&bitmap1));
-    /// ```
-    pub fn is_subset(&self, other: &Self) -> bool {
-        for (k, v) in self.map.iter() {
-            if v.is_empty() {
-                continue;
-            }
-            match other.map.get(k) {
-                None => return false,
-                Some(other_v) => {
-                    if !v.is_subset(other_v) {
-                        return false;
-                    }
-                }
-            }
-        }
-        true
-    }
-
-    /// Return true if all the elements of Self are in &other and &other is strictly greater
-    /// than Self.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use croaring::Treemap;
-    ///
-    /// let bitmap1: Treemap = (5..9).collect();
-    /// let bitmap2: Treemap = (5..8).collect();
-    /// let bitmap3: Treemap = (5..10).collect();
-    /// let bitmap4: Treemap = (9..11).collect();
-    ///
-    /// assert!(bitmap2.is_subset(&bitmap1));
-    /// assert!(!bitmap3.is_subset(&bitmap1));
-    /// assert!(!bitmap4.is_subset(&bitmap1));
-    /// ```
-    pub fn is_strict_subset(&self, other: &Self) -> bool {
-        self.is_subset(other) && self.cardinality() != other.cardinality()
+    pub(super) fn get_or_create(&mut self, bucket: u32) -> &mut Bitmap {
+        self.map.entry(bucket).or_insert_with(Bitmap::create)
     }
 }
 

--- a/croaring/src/treemap/imp.rs
+++ b/croaring/src/treemap/imp.rs
@@ -246,7 +246,7 @@ impl Treemap {
     /// let mut treemap = Treemap::create();
     /// treemap.add_range(1..5);
     /// treemap.flip(2..10);
-    /// assert_eq!(treemap.cardinality(), 4);
+    /// assert_eq!(treemap.cardinality(), 6);
     /// assert_eq!(treemap.iter().collect::<Vec<_>>(), vec![1, 5, 6, 7, 8, 9]);
     /// ```
     pub fn flip<R: RangeBounds<u64>>(&mut self, range: R) {

--- a/croaring/src/treemap/mod.rs
+++ b/croaring/src/treemap/mod.rs
@@ -1,8 +1,8 @@
 //! Treemap is a RoaringBitmap-based structure that supports 64bit unsigned
-//! integer values. Implemented as a BTreeMap.
+//! integer values. Implemented as a [`BTreeMap`].
 //!
-//! Java version can be found at https://github.com/RoaringBitmap/RoaringBitmap/blob/master/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
-//! C++ version - https://github.com/RoaringBitmap/CRoaring/blob/master/cpp/roaring64map.hh
+//! Java version can be found at <https://github.com/RoaringBitmap/RoaringBitmap/blob/master/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java>
+//! C++ version - <https://github.com/RoaringBitmap/CRoaring/blob/master/cpp/roaring64map.hh>
 //!
 //! # Example
 //!

--- a/croaring/src/treemap/mod.rs
+++ b/croaring/src/treemap/mod.rs
@@ -29,7 +29,7 @@ mod ops;
 mod serialization;
 mod util;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Treemap {
     pub map: BTreeMap<u32, Bitmap>,
 }


### PR DESCRIPTION
I believe this adds all the operations from C++'s Roaring64Map.

Additionally, fixes suggested by `cargo clippy -- -W clippy::pedantic`, mostly adding `must_use` to most functions where the function is only useful for its output.