### PR TITLE
Use a more idiomatic trait-based implementation of serialization for treemaps

### DIFF
--- a/croaring/src/bitmap/mod.rs
+++ b/croaring/src/bitmap/mod.rs
@@ -91,4 +91,4 @@ mod view;
 
 pub use self::iter::BitmapIterator;
 pub use self::lazy::LazyBitmap;
-pub use self::serialization::{Frozen, Native, Portable};
+pub use self::serialization::{Deserializer, Serializer, ViewDeserializer};

--- a/croaring/src/bitmap/serialization.rs
+++ b/croaring/src/bitmap/serialization.rs
@@ -184,14 +184,10 @@ impl Serializer for Frozen {
 
         let mut offset = dst.len();
         if dst.capacity() < dst.len() + len
-            || (dst.as_ptr_range().end as usize) % Self::REQUIRED_ALIGNMENT != 0
+            || Self::required_padding(dst.as_ptr_range().end as usize) != 0
         {
-            // Need to be able to add up to 31 extra bytes to align to 32 bytes
-            dst.reserve(len.checked_add(Self::REQUIRED_ALIGNMENT - 1).unwrap());
-            let extra_offset = match (dst.as_ptr_range().end as usize) % Self::REQUIRED_ALIGNMENT {
-                0 => 0,
-                r => Self::REQUIRED_ALIGNMENT - r,
-            };
+            dst.reserve(len.checked_add(Self::MAX_PADDING).unwrap());
+            let extra_offset = Self::required_padding(dst.as_ptr_range().end as usize);
             offset = offset.checked_add(extra_offset).unwrap();
             // we must initialize up to offset
             dst.resize(offset, 0);

--- a/croaring/src/bitmap/serialization.rs
+++ b/croaring/src/bitmap/serialization.rs
@@ -4,11 +4,33 @@ use crate::serialization::{Frozen, Native, Portable};
 use std::ffi::{c_char, c_void};
 
 pub trait Serializer {
+    /// Serialize a bitmap into bytes, using the provided vec buffer to store the serialized data
+    ///
+    /// Note that some serializers ([Frozen]) may require that the bitmap is aligned specially,
+    /// this method will ensure that the returned slice of bytes is aligned correctly, by adding
+    /// additional padding before the serialized data if required.
+    ///
+    /// The contents of the provided vec buffer will not be overwritten: only new data will be
+    /// appended to the end of the buffer. If the buffer has enough capacity, and the current
+    /// end of the buffer is correctly aligned, then no additional allocations will be performed.
     fn serialize_into<'a>(bitmap: &Bitmap, dst: &'a mut Vec<u8>) -> &'a [u8];
+    /// Get the number of bytes required to serialize this bitmap
+    ///
+    /// This does not include any additional padding which may be required to align the bitmap
     fn get_serialized_size_in_bytes(bitmap: &Bitmap) -> usize;
 }
 
 pub trait Deserializer {
+    /// Try to deserialize a bitmap from the beginning of the provided buffer
+    ///
+    /// If the buffer starts with the serialized representation of a bitmap, then
+    /// this method will return a new bitmap containing the deserialized data.
+    ///
+    /// If the buffer does not start with a serialized bitmap (or contains an invalidly
+    /// truncated bitmap), then this method will return `None`.
+    ///
+    /// To determine how many bytes were consumed from the buffer, use the
+    /// [`Serializer::get_serialized_size_in_bytes`] method on the returned bitmap.
     fn try_deserialize(buffer: &[u8]) -> Option<Bitmap>;
 }
 

--- a/croaring/src/bitmap/serialization.rs
+++ b/croaring/src/bitmap/serialization.rs
@@ -1,4 +1,5 @@
 use super::{Bitmap, BitmapView};
+use crate::serialization::{Frozen, Native, Portable};
 
 use std::ffi::{c_char, c_void};
 
@@ -14,10 +15,6 @@ pub trait Deserializer {
 pub trait ViewDeserializer {
     unsafe fn deserialize_view(data: &[u8]) -> BitmapView<'_>;
 }
-
-/// The `Portable` format is meant to be compatible with other roaring bitmap libraries, such as Go or Java.
-/// It's defined here: <https://github.com/RoaringBitmap/RoaringFormatSpec>
-pub enum Portable {}
 
 impl Serializer for Portable {
     /// Serializes a bitmap to a slice of bytes in portable format.
@@ -92,11 +89,6 @@ impl ViewDeserializer for Portable {
     }
 }
 
-/// The `Native` format format can sometimes be more space efficient than [`Portable`], e.g. when
-/// the data is sparse. It's not compatible with Java and Go implementations. Use [`Portable`] for
-/// that purpose.
-pub enum Native {}
-
 impl Serializer for Native {
     /// Serializes a bitmap to a slice of bytes in native format.
     /// See [`Bitmap::serialize_into`] for examples.
@@ -146,11 +138,6 @@ impl Deserializer for Native {
         }
     }
 }
-
-/// The `Frozen` format imitates memory layout of the underlying C library.
-/// This reduces amount of allocations and copying required during deserialization, though
-/// `Portable` offers comparable performance.
-pub enum Frozen {}
 
 impl Serializer for Frozen {
     /// Serializes a bitmap to a slice of bytes in "frozen" format.

--- a/croaring/src/lib.rs
+++ b/croaring/src/lib.rs
@@ -3,7 +3,7 @@ pub mod bitset;
 pub mod serialization;
 pub mod treemap;
 
-pub use serialization::{Frozen, Native, Portable};
+pub use serialization::*;
 
 pub use bitmap::Bitmap;
 pub use bitmap::BitmapIterator;

--- a/croaring/src/lib.rs
+++ b/croaring/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod bitmap;
 pub mod bitset;
-pub mod serialization;
 pub mod treemap;
+
+mod serialization;
 
 pub use serialization::*;
 

--- a/croaring/src/lib.rs
+++ b/croaring/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod bitmap;
 pub mod bitset;
+pub mod serialization;
 pub mod treemap;
+
+pub use serialization::{Frozen, Native, Portable};
 
 pub use bitmap::Bitmap;
 pub use bitmap::BitmapIterator;
@@ -8,4 +11,3 @@ pub use bitset::Bitset;
 pub use treemap::Treemap;
 
 pub use bitmap::BitmapView;
-pub use bitmap::{Frozen, Native, Portable};

--- a/croaring/src/serialization.rs
+++ b/croaring/src/serialization.rs
@@ -24,6 +24,17 @@ pub enum Frozen {}
 impl Frozen {
     /// The frozen format requires bitmaps are aligned to 32 bytes.
     pub const REQUIRED_ALIGNMENT: usize = 32;
+
+    // The most padding required to get 32 byte alignment is 31 bytes.
+    pub(crate) const MAX_PADDING: usize = Self::REQUIRED_ALIGNMENT - 1;
+
+    #[inline]
+    pub(crate) const fn required_padding(x: usize) -> usize {
+        match x % Self::REQUIRED_ALIGNMENT {
+            0 => 0,
+            r => Self::REQUIRED_ALIGNMENT - r,
+        }
+    }
 }
 
 /// The `JvmLegacy` format is meant to be compatible with the original Java implementation of `Roaring64NavigableMap`

--- a/croaring/src/serialization.rs
+++ b/croaring/src/serialization.rs
@@ -19,3 +19,10 @@ impl Frozen {
     /// The frozen format requires bitmaps are aligned to 32 bytes.
     pub const REQUIRED_ALIGNMENT: usize = 32;
 }
+
+/// The `JvmLegacy` format is meant to be compatible with the original Java implementation of Roaring64NavigableMap
+///
+/// It is used only for [Treemap][crate::Treemap]s, not bitmaps.
+///
+/// See <https://github.com/RoaringBitmap/RoaringBitmap/blob/2669c4f5a49ee7da5ff4cd70e18ee5520018d6a5/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java#L1215-L1238>
+pub enum JvmLegacy {}

--- a/croaring/src/serialization.rs
+++ b/croaring/src/serialization.rs
@@ -1,0 +1,13 @@
+/// The `Portable` format is meant to be compatible with other roaring bitmap libraries, such as Go or Java.
+/// It's defined here: <https://github.com/RoaringBitmap/RoaringFormatSpec>
+pub enum Portable {}
+
+/// The `Native` format format can sometimes be more space efficient than [`Portable`], e.g. when
+/// the data is sparse. It's not compatible with Java and Go implementations. Use [`Portable`] for
+/// that purpose.
+pub enum Native {}
+
+/// The `Frozen` format imitates memory layout of the underlying C library.
+/// This reduces amount of allocations and copying required during deserialization, though
+/// `Portable` offers comparable performance.
+pub enum Frozen {}

--- a/croaring/src/serialization.rs
+++ b/croaring/src/serialization.rs
@@ -1,5 +1,7 @@
 /// The `Portable` format is meant to be compatible with other roaring bitmap libraries, such as Go or Java.
 ///
+/// Note despite the name, it is not fully portable: it depends on native endianness.
+///
 /// It's defined here: <https://github.com/RoaringBitmap/RoaringFormatSpec>
 pub enum Portable {}
 
@@ -13,6 +15,10 @@ pub enum Native {}
 ///
 /// This reduces amount of allocations and copying required during deserialization, though
 /// `Portable` offers comparable performance.
+///
+/// Note that because frozen serialization format imitates C memory layout
+/// of roaring_bitmap_t, it is not fixed. It is different on big/little endian
+/// platforms and can be changed in future.
 pub enum Frozen {}
 
 impl Frozen {

--- a/croaring/src/serialization.rs
+++ b/croaring/src/serialization.rs
@@ -1,13 +1,20 @@
 /// The `Portable` format is meant to be compatible with other roaring bitmap libraries, such as Go or Java.
+///
 /// It's defined here: <https://github.com/RoaringBitmap/RoaringFormatSpec>
 pub enum Portable {}
 
-/// The `Native` format format can sometimes be more space efficient than [`Portable`], e.g. when
-/// the data is sparse. It's not compatible with Java and Go implementations. Use [`Portable`] for
-/// that purpose.
+/// The `Native` format format can sometimes be more space efficient than [`Portable`],
+///
+/// e.g. when the data is sparse. It's not compatible with Java and Go implementations.
+/// Use [`Portable`] for that purpose.
 pub enum Native {}
 
 /// The `Frozen` format imitates memory layout of the underlying C library.
+///
 /// This reduces amount of allocations and copying required during deserialization, though
 /// `Portable` offers comparable performance.
 pub enum Frozen {}
+
+impl Frozen {
+    pub const REQUIRED_ALIGNMENT: usize = 32;
+}

--- a/croaring/src/serialization.rs
+++ b/croaring/src/serialization.rs
@@ -17,7 +17,7 @@ pub enum Native {}
 /// `Portable` offers comparable performance.
 ///
 /// Note that because frozen serialization format imitates C memory layout
-/// of roaring_bitmap_t, it is not fixed. It is different on big/little endian
+/// of `roaring_bitmap_t`, it is not fixed. It is different on big/little endian
 /// platforms and can be changed in future.
 pub enum Frozen {}
 
@@ -26,7 +26,7 @@ impl Frozen {
     pub const REQUIRED_ALIGNMENT: usize = 32;
 }
 
-/// The `JvmLegacy` format is meant to be compatible with the original Java implementation of Roaring64NavigableMap
+/// The `JvmLegacy` format is meant to be compatible with the original Java implementation of `Roaring64NavigableMap`
 ///
 /// It is used only for [Treemap][crate::Treemap]s, not bitmaps.
 ///

--- a/croaring/src/serialization.rs
+++ b/croaring/src/serialization.rs
@@ -16,5 +16,6 @@ pub enum Native {}
 pub enum Frozen {}
 
 impl Frozen {
+    /// The frozen format requires bitmaps are aligned to 32 bytes.
     pub const REQUIRED_ALIGNMENT: usize = 32;
 }

--- a/croaring/src/treemap/imp.rs
+++ b/croaring/src/treemap/imp.rs
@@ -17,6 +17,7 @@ impl Treemap {
     /// use croaring::Treemap;
     /// let treemap = Treemap::new();
     /// ```
+    #[must_use]
     pub fn new() -> Self {
         Treemap {
             map: BTreeMap::new(),
@@ -35,6 +36,7 @@ impl Treemap {
     /// let treemap = Treemap::from_bitmap(bitmap);
     /// assert_eq!(treemap.cardinality(), 3);
     /// ```
+    #[must_use]
     pub fn from_bitmap(bitmap: Bitmap) -> Self {
         let mut map = BTreeMap::new();
         map.insert(0, bitmap);
@@ -160,6 +162,7 @@ impl Treemap {
     ///
     /// let mut treemap = Treemap::new();
     /// ```
+    #[must_use]
     pub fn contains(&self, value: u64) -> bool {
         let (hi, lo) = util::split(value);
         match self.map.get(&hi) {
@@ -184,6 +187,7 @@ impl Treemap {
     ///
     /// assert!(!treemap.is_empty());
     /// ```
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.map.values().all(Bitmap::is_empty)
     }
@@ -198,6 +202,7 @@ impl Treemap {
     /// let mut treemap = Treemap::new();
     /// assert!(!treemap.is_full());
     /// ```
+    #[must_use]
     pub fn is_full(&self) -> bool {
         // only bother to check if map is fully saturated
         if self.map.len() != usize::try_from(u32::MAX).unwrap() + 1 {
@@ -224,6 +229,7 @@ impl Treemap {
     /// assert!(bitmap3.is_subset(&bitmap1));
     /// assert!(!bitmap4.is_subset(&bitmap1));
     /// ```
+    #[must_use]
     pub fn is_subset(&self, other: &Treemap) -> bool {
         self.map.iter().all(|(key, lhs)| {
             lhs.is_empty() || other.map.get(key).map_or(false, |rhs| lhs.is_subset(rhs))
@@ -231,6 +237,7 @@ impl Treemap {
     }
 
     /// Returns true if this bitmap is a strict subset of `other`
+    #[must_use]
     pub fn is_strict_subset(&self, other: &Treemap) -> bool {
         self.is_subset(other) && self.cardinality() != other.cardinality()
     }
@@ -497,6 +504,7 @@ impl Treemap {
     /// assert_eq!(treemap.select(10), Some(20));
     /// assert_eq!(treemap.select(11), None);
     /// ```
+    #[must_use]
     pub fn select(&self, mut rank: u64) -> Option<u64> {
         for (&key, bitmap) in &self.map {
             let sub_cardinality = bitmap.cardinality();
@@ -515,6 +523,7 @@ impl Treemap {
     }
 
     /// Returns the number of elements that are smaller or equal to `value`
+    #[must_use]
     pub fn rank(&self, value: u64) -> u64 {
         let (hi, lo) = util::split(value);
         let mut rank = 0;
@@ -539,6 +548,7 @@ impl Treemap {
     /// The difference with the `rank` method is that this method will return
     /// None if the value is not in the set, whereas `rank` will always return a value
     #[doc(alias = "get_index")]
+    #[must_use]
     pub fn position(&self, value: u64) -> Option<u64> {
         let (hi, lo) = util::split(value);
         let mut range = self.map.range(..=hi);
@@ -571,6 +581,7 @@ impl Treemap {
     ///
     /// assert_eq!(treemap.cardinality(), 2);
     /// ```
+    #[must_use]
     pub fn cardinality(&self) -> u64 {
         self.map.values().map(Bitmap::cardinality).sum()
     }
@@ -1124,6 +1135,7 @@ impl Treemap {
     /// See example of [`Self::serialize`] function.
     ///
     /// On invalid input returns empty treemap.
+    #[must_use]
     pub fn deserialize<D: Deserializer>(buffer: &[u8]) -> Self {
         Self::try_deserialize::<D>(buffer).unwrap_or_default()
     }
@@ -1203,7 +1215,7 @@ impl Treemap {
     }
 
     pub(super) fn get_or_create(&mut self, bucket: u32) -> &mut Bitmap {
-        self.map.entry(bucket).or_insert_with(Bitmap::new)
+        self.map.entry(bucket).or_default()
     }
 }
 

--- a/croaring/src/treemap/iter.rs
+++ b/croaring/src/treemap/iter.rs
@@ -73,6 +73,7 @@ impl Treemap {
     /// assert_eq!(iterator.next(), Some(u64::MAX));
     /// assert_eq!(iterator.next(), None);
     /// ```
+    #[must_use]
     pub fn iter(&self) -> TreemapIterator {
         TreemapIterator::new(self)
     }

--- a/croaring/src/treemap/mod.rs
+++ b/croaring/src/treemap/mod.rs
@@ -29,6 +29,9 @@ mod ops;
 mod serialization;
 mod util;
 
+pub use serialization::{Serializer, Deserializer};
+pub use iter::TreemapIterator;
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct Treemap {
     pub map: BTreeMap<u32, Bitmap>,

--- a/croaring/src/treemap/mod.rs
+++ b/croaring/src/treemap/mod.rs
@@ -33,5 +33,3 @@ mod util;
 pub struct Treemap {
     pub map: BTreeMap<u32, Bitmap>,
 }
-
-pub use crate::treemap::serialization::{JvmSerializer, NativeSerializer};

--- a/croaring/src/treemap/mod.rs
+++ b/croaring/src/treemap/mod.rs
@@ -29,8 +29,8 @@ mod ops;
 mod serialization;
 mod util;
 
-pub use serialization::{Serializer, Deserializer};
 pub use iter::TreemapIterator;
+pub use serialization::{Deserializer, Serializer};
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct Treemap {

--- a/croaring/src/treemap/ops.rs
+++ b/croaring/src/treemap/ops.rs
@@ -255,7 +255,7 @@ impl BitOrAssign for Treemap {
     /// ```
     #[inline]
     fn bitor_assign(&mut self, other: Treemap) {
-        self.or_inplace(&other)
+        self.or_inplace(&other);
     }
 }
 
@@ -381,7 +381,7 @@ impl BitXorAssign for Treemap {
     /// ```
     #[inline]
     fn bitxor_assign(&mut self, other: Treemap) {
-        self.xor_inplace(&other)
+        self.xor_inplace(&other);
     }
 }
 
@@ -515,6 +515,6 @@ impl SubAssign for Treemap {
     /// ```
     #[inline]
     fn sub_assign(&mut self, other: Treemap) {
-        self.andnot_inplace(&other)
+        self.andnot_inplace(&other);
     }
 }

--- a/croaring/src/treemap/serialization.rs
+++ b/croaring/src/treemap/serialization.rs
@@ -142,7 +142,7 @@ impl Serializer for Portable {
     }
 
     /// Computes the serialized size in bytes of the Treemap in portable format.
-    /// See [`Treemap::get_size_in_bytes`] for examples.
+    /// See [`Treemap::get_serialized_size_in_bytes`] for examples.
     fn get_serialized_size_in_bytes(treemap: &Treemap) -> usize {
         size_in_bytes_impl::<Self>(treemap)
     }
@@ -171,7 +171,7 @@ impl Serializer for Native {
     }
 
     /// Computes the serialized size in bytes of the Treemap in native format.
-    /// See [`Treemap::get_size_in_bytes`] for examples.
+    /// See [`Treemap::get_serialized_size_in_bytes`] for examples.
     fn get_serialized_size_in_bytes(treemap: &Treemap) -> usize {
         size_in_bytes_impl::<Self>(treemap)
     }
@@ -260,7 +260,7 @@ impl Serializer for Frozen {
     }
 
     /// Computes the serialized size in bytes of the Treemap in frozen format.
-    /// See [`Treemap::get_size_in_bytes`] for examples.
+    /// See [`Treemap::get_serialized_size_in_bytes`] for examples.
     fn get_serialized_size_in_bytes(treemap: &Treemap) -> usize {
         // Yes, the frozen format changes based on the size of usize
         const METADATA_SIZE: usize = size_of::<usize>() + size_of::<u32>();

--- a/croaring/src/treemap/serialization.rs
+++ b/croaring/src/treemap/serialization.rs
@@ -1,12 +1,26 @@
 use crate::serialization::{Frozen, Native, Portable};
-use crate::Treemap;
+use crate::{bitmap, Treemap};
 use crate::{Bitmap, JvmLegacy};
 use std::collections::BTreeMap;
+use std::io;
+use std::io::Write as _;
 
 use byteorder::{BigEndian, NativeEndian, ReadBytesExt, WriteBytesExt};
 use std::mem::size_of;
 
 pub trait Serializer {
+    /// Serialize a treemap into a writer
+    ///
+    /// Returns the number of bytes written, or an error if writing failed
+    ///
+    /// Note tha some serializers ([Frozen]) may require that the bitmap is aligned specially when
+    /// reading: this method does not perform any extra alignment. See [Self::serialize_into]
+    /// for a method which will return a slice of bytes which are guaranteed to be aligned correctly
+    /// in memory
+    fn serialize_into_writer<W>(treemap: &Treemap, dst: W) -> io::Result<usize>
+    where
+        W: io::Write;
+
     /// Serialize a treemap into bytes, using the provided vec buffer to store the serialized data
     ///
     /// Note that some serializers ([Frozen]) may require that bitmaps are aligned specially, this
@@ -16,6 +30,10 @@ pub trait Serializer {
     /// The contents of the provided vec buffer will not be overwritten: only new data will be
     /// appended to the end of the buffer. If the buffer has enough capacity, and the current
     /// end of the buffer is correctly aligned, then no additional allocations will be performed.
+    ///
+    /// Note that this method requires keeping the serialized data in memory: see also the
+    /// [`Self::serialize_into_writer`] method which will write the serialized data directly to a
+    /// writer
     fn serialize_into<'a>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8];
 
     /// Get the number of bytes required to serialize this bitmap
@@ -25,12 +43,20 @@ pub trait Serializer {
 }
 
 pub trait Deserializer {
-    fn try_deserialize(buffer: &[u8]) -> Option<Treemap>;
+    /// Try to deserialize a treemap from the beginning of the provided buffer
+    ///
+    /// If the buffer starts with the serialized representation of a treemap, then
+    /// this method will return a tuple containing a new treemap containing the deserialized data,
+    /// and the number of bytes consumed from the buffer.
+    ///
+    /// If the buffer does not start with a serialized treemap (or contains an invalidly
+    /// truncated treemap), then this method will return `None`.
+    fn try_deserialize(buffer: &[u8]) -> Option<(Treemap, usize)>;
 }
 
 fn serialize_impl<'a, S>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8]
 where
-    S: crate::bitmap::Serializer,
+    S: bitmap::Serializer,
 {
     let start_idx = dst.len();
     let map_len = u64::try_from(treemap.map.len()).unwrap();
@@ -49,9 +75,30 @@ where
     &dst[start_idx..]
 }
 
+fn serialize_writer_impl<S, W>(treemap: &Treemap, dst: W) -> io::Result<usize>
+where
+    S: bitmap::Serializer,
+    W: io::Write,
+{
+    let mut dst = OffsetTrackingWriter::new(dst);
+    let map_len = u64::try_from(treemap.map.len()).unwrap();
+    dst.write_u64::<NativeEndian>(map_len)?;
+
+    let mut buf = Vec::new();
+
+    for (&key, bitmap) in &treemap.map {
+        dst.write_u32::<NativeEndian>(key)?;
+
+        let bitmap_serialized = bitmap.serialize_into::<S>(&mut buf);
+        dst.write_all(bitmap_serialized)?;
+        buf.clear();
+    }
+    Ok(dst.bytes_written)
+}
+
 fn size_in_bytes_impl<S>(treemap: &Treemap) -> usize
 where
-    S: crate::bitmap::Serializer,
+    S: bitmap::Serializer,
 {
     let overhead = size_of::<u64>() + treemap.map.len() * size_of::<u32>();
     let total_sizes = treemap
@@ -62,10 +109,11 @@ where
     overhead + total_sizes
 }
 
-fn deserialize_impl<S>(mut buffer: &[u8]) -> Option<Treemap>
+fn deserialize_impl<S>(mut buffer: &[u8]) -> Option<(Treemap, usize)>
 where
-    S: crate::bitmap::Serializer + crate::bitmap::Deserializer,
+    S: bitmap::Serializer + bitmap::Deserializer,
 {
+    let start_len = buffer.len();
     let map_len = buffer.read_u64::<NativeEndian>().ok()?;
     let mut map = BTreeMap::new();
     for _ in 0..map_len {
@@ -74,10 +122,19 @@ where
         buffer = &buffer[bitmap.get_serialized_size_in_bytes::<S>()..];
         map.insert(key, bitmap);
     }
-    Some(Treemap { map })
+    Some((Treemap { map }, start_len - buffer.len()))
 }
 
 impl Serializer for Portable {
+    /// Serializes a Treemap to a writer in portable format.
+    /// See [`Treemap::serialize_into_writer`] for examples.
+    fn serialize_into_writer<W>(treemap: &Treemap, dst: W) -> io::Result<usize>
+    where
+        W: io::Write,
+    {
+        serialize_writer_impl::<Self, W>(treemap, dst)
+    }
+
     /// Serializes a Treemap to a slice of bytes in portable format.
     /// See [`Treemap::serialize_into`] for examples.
     fn serialize_into<'a>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8] {
@@ -92,12 +149,21 @@ impl Serializer for Portable {
 }
 
 impl Deserializer for Portable {
-    fn try_deserialize(buffer: &[u8]) -> Option<Treemap> {
+    fn try_deserialize(buffer: &[u8]) -> Option<(Treemap, usize)> {
         deserialize_impl::<Self>(buffer)
     }
 }
 
 impl Serializer for Native {
+    /// Serializes a Treemap to a writer in native format.
+    /// See [`Treemap::serialize_into_writer`] for examples.
+    fn serialize_into_writer<W>(treemap: &Treemap, dst: W) -> io::Result<usize>
+    where
+        W: io::Write,
+    {
+        serialize_writer_impl::<Self, W>(treemap, dst)
+    }
+
     /// Serializes a Treemap to a slice of bytes in native format.
     /// See [`Treemap::serialize_into`] for examples.
     fn serialize_into<'a>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8] {
@@ -112,17 +178,50 @@ impl Serializer for Native {
 }
 
 impl Deserializer for Native {
-    fn try_deserialize(buffer: &[u8]) -> Option<Treemap> {
+    fn try_deserialize(buffer: &[u8]) -> Option<(Treemap, usize)> {
         deserialize_impl::<Self>(buffer)
     }
 }
 
+const FROZEN_BITMAP_METADATA_SIZE: usize = size_of::<usize>() + size_of::<u32>();
+
 impl Serializer for Frozen {
+    /// Serializes a Treemap to a writer in frozen format.
+    /// See [`Treemap::serialize_into_writer`] for examples.
+    fn serialize_into_writer<W>(treemap: &Treemap, dst: W) -> io::Result<usize>
+    where
+        W: io::Write,
+    {
+        const MAX_PADDING: usize = Frozen::REQUIRED_ALIGNMENT - 1;
+        const FULL_PADDING: [u8; MAX_PADDING] = [0; MAX_PADDING];
+
+        let mut dst = OffsetTrackingWriter::new(dst);
+
+        let map_size = u64::try_from(treemap.map.len()).unwrap();
+        dst.write_all(&u64::to_ne_bytes(map_size))?;
+
+        let mut buf = Vec::new();
+        for (&key, bitmap) in &treemap.map {
+            let bitmap_serialized = bitmap.serialize_into::<Self>(&mut buf);
+            let required_padding =
+                frozen_needed_alignment(dst.bytes_written + FROZEN_BITMAP_METADATA_SIZE);
+
+            dst.write_all(&FULL_PADDING[..required_padding])?;
+            dst.write_all(&usize::to_ne_bytes(bitmap_serialized.len()))?;
+            dst.write_all(&u32::to_ne_bytes(key))?;
+
+            debug_assert_eq!(dst.bytes_written % Self::REQUIRED_ALIGNMENT, 0);
+            dst.write_all(bitmap_serialized)?;
+
+            buf.clear();
+        }
+
+        Ok(dst.bytes_written)
+    }
+
     /// Serializes a Treemap to a slice of bytes in frozen format.
     /// See [`Treemap::serialize_into`] for examples.
     fn serialize_into<'a>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8] {
-        const METADATA_SIZE: usize = size_of::<usize>() + size_of::<u32>();
-
         let len = Self::get_serialized_size_in_bytes(treemap);
         let mut offset = dst.len();
         if dst.capacity() < dst.len() + len
@@ -130,10 +229,7 @@ impl Serializer for Frozen {
         {
             // Need to be able to add up to 31 extra bytes to align to 32 bytes
             dst.reserve(len.checked_add(Self::REQUIRED_ALIGNMENT - 1).unwrap());
-            let extra_offset = match (dst.as_ptr() as usize + offset) % Self::REQUIRED_ALIGNMENT {
-                0 => 0,
-                r => Self::REQUIRED_ALIGNMENT - r,
-            };
+            let extra_offset = frozen_needed_alignment(dst.as_ptr() as usize + offset);
             offset = offset.checked_add(extra_offset).unwrap();
             // we must initialize up to offset
             dst.resize(offset, 0);
@@ -142,15 +238,11 @@ impl Serializer for Frozen {
         debug_assert!(dst.capacity() >= total_len);
 
         let map_size = u64::try_from(treemap.map.len()).unwrap();
-        dst.extend_from_slice(&map_size.to_be_bytes());
+        dst.extend_from_slice(&map_size.to_ne_bytes());
 
         treemap.map.iter().for_each(|(&key, bitmap)| {
-            let extra_padding = match (dst.as_ptr_range().end as usize + METADATA_SIZE)
-                % Self::REQUIRED_ALIGNMENT
-            {
-                0 => 0,
-                r => Self::REQUIRED_ALIGNMENT - r,
-            };
+            let end_with_metadata = dst.as_ptr_range().end as usize + FROZEN_BITMAP_METADATA_SIZE;
+            let extra_padding = frozen_needed_alignment(end_with_metadata);
             dst.resize(dst.len() + extra_padding, 0);
 
             let frozen_size_in_bytes: usize = bitmap.get_serialized_size_in_bytes::<Self>();
@@ -188,6 +280,28 @@ impl Serializer for Frozen {
 }
 
 impl Serializer for JvmLegacy {
+    fn serialize_into_writer<W>(treemap: &Treemap, dst: W) -> io::Result<usize>
+    where
+        W: io::Write,
+    {
+        let mut dst = OffsetTrackingWriter::new(dst);
+        // Push a boolean false indicating that the values are not signed
+        dst.write_u8(0)?;
+
+        let bitmap_count: u32 = treemap.map.len().try_into().unwrap();
+        dst.write_u32::<BigEndian>(bitmap_count)?;
+
+        let mut buf = Vec::new();
+        for (&key, bitmap) in &treemap.map {
+            dst.write_u32::<BigEndian>(key)?;
+            let bitmap_serialized = bitmap.serialize_into::<Portable>(&mut buf);
+            dst.write_all(bitmap_serialized)?;
+            buf.clear();
+        }
+
+        Ok(dst.bytes_written)
+    }
+
     fn serialize_into<'a>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8] {
         let start_idx = dst.len();
         // Push a boolean false indicating that the values are not signed
@@ -215,7 +329,8 @@ impl Serializer for JvmLegacy {
 }
 
 impl Deserializer for JvmLegacy {
-    fn try_deserialize(mut buffer: &[u8]) -> Option<Treemap> {
+    fn try_deserialize(mut buffer: &[u8]) -> Option<(Treemap, usize)> {
+        let start_len = buffer.len();
         // Ignored, we assume that the values are not signed
         let _is_signed = buffer.read_u8().ok()?;
 
@@ -228,6 +343,46 @@ impl Deserializer for JvmLegacy {
             map.insert(key, bitmap);
         }
 
-        Some(Treemap { map })
+        Some((Treemap { map }, start_len - buffer.len()))
+    }
+}
+
+#[inline]
+fn frozen_needed_alignment(x: usize) -> usize {
+    match x % Frozen::REQUIRED_ALIGNMENT {
+        0 => 0,
+        r => Frozen::REQUIRED_ALIGNMENT - r,
+    }
+}
+
+struct OffsetTrackingWriter<W> {
+    writer: W,
+    bytes_written: usize,
+}
+
+impl<W> OffsetTrackingWriter<W> {
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer,
+            bytes_written: 0,
+        }
+    }
+}
+
+impl<W: io::Write> io::Write for OffsetTrackingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.writer.write(buf)?;
+        self.bytes_written += written;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.writer.write_all(buf)?;
+        self.bytes_written += buf.len();
+        Ok(())
     }
 }

--- a/croaring/src/treemap/serialization.rs
+++ b/croaring/src/treemap/serialization.rs
@@ -8,13 +8,14 @@ use std::io::Write as _;
 use byteorder::{BigEndian, NativeEndian, ReadBytesExt, WriteBytesExt};
 use std::mem::size_of;
 
+/// Trait for different formats of treemap deserialization
 pub trait Serializer {
     /// Serialize a treemap into a writer
     ///
     /// Returns the number of bytes written, or an error if writing failed
     ///
-    /// Note tha some serializers ([Frozen]) may require that the bitmap is aligned specially when
-    /// reading: this method does not perform any extra alignment. See [Self::serialize_into]
+    /// Note tha some serializers ([`Frozen`]) may require that the bitmap is aligned specially when
+    /// reading: this method does not perform any extra alignment. See [`Self::serialize_into`]
     /// for a method which will return a slice of bytes which are guaranteed to be aligned correctly
     /// in memory
     fn serialize_into_writer<W>(treemap: &Treemap, dst: W) -> io::Result<usize>
@@ -23,7 +24,7 @@ pub trait Serializer {
 
     /// Serialize a treemap into bytes, using the provided vec buffer to store the serialized data
     ///
-    /// Note that some serializers ([Frozen]) may require that bitmaps are aligned specially, this
+    /// Note that some serializers ([`Frozen`]) may require that bitmaps are aligned specially, this
     /// method will ensure that the returned slice of bytes is aligned correctly so that each bitmap
     /// is correctly aligned, adding additional padding before the serialized data if required.
     ///
@@ -42,6 +43,7 @@ pub trait Serializer {
     fn get_serialized_size_in_bytes(treemap: &Treemap) -> usize;
 }
 
+/// Trait for different formats of treemap deserialization
 pub trait Deserializer {
     /// Try to deserialize a treemap from the beginning of the provided buffer
     ///
@@ -104,7 +106,7 @@ where
     let total_sizes = treemap
         .map
         .values()
-        .map(|b| b.get_serialized_size_in_bytes::<S>())
+        .map(Bitmap::get_serialized_size_in_bytes::<S>)
         .sum::<usize>();
     overhead + total_sizes
 }
@@ -322,7 +324,7 @@ impl Serializer for JvmLegacy {
         let total_sizes = treemap
             .map
             .values()
-            .map(|b| b.get_serialized_size_in_bytes::<Portable>())
+            .map(Bitmap::get_serialized_size_in_bytes::<Portable>)
             .sum::<usize>();
         overhead + total_sizes
     }

--- a/croaring/src/treemap/serialization.rs
+++ b/croaring/src/treemap/serialization.rs
@@ -1,156 +1,233 @@
+use crate::serialization::{Frozen, Native, Portable};
 use crate::Treemap;
-use crate::{Bitmap, Portable};
+use crate::{Bitmap, JvmLegacy};
+use std::collections::BTreeMap;
 
 use byteorder::{BigEndian, NativeEndian, ReadBytesExt, WriteBytesExt};
-use std::io::{Cursor, Result, Seek, SeekFrom};
 use std::mem::size_of;
 
-pub trait Serializer {}
+pub trait Serializer {
+    /// Serialize a treemap into bytes, using the provided vec buffer to store the serialized data
+    ///
+    /// Note that some serializers ([Frozen]) may require that bitmaps are aligned specially, this
+    /// method will ensure that the returned slice of bytes is aligned correctly so that each bitmap
+    /// is correctly aligned, adding additional padding before the serialized data if required.
+    ///
+    /// The contents of the provided vec buffer will not be overwritten: only new data will be
+    /// appended to the end of the buffer. If the buffer has enough capacity, and the current
+    /// end of the buffer is correctly aligned, then no additional allocations will be performed.
+    fn serialize_into<'a>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8];
 
-/// croaring::Treemap serializer that is compatible with C++ version found in
-/// CRoaring at https://github.com/RoaringBitmap/CRoaring/blob/master/cpp/roaring64map.hh
-pub trait NativeSerializer: Serializer {
-    type Item;
-
-    fn serialize(&self) -> Result<Vec<u8>>;
-    fn deserialize(buffer: &[u8]) -> Result<Self::Item>;
-    fn get_serialized_size_in_bytes(&self) -> usize;
+    /// Get the number of bytes required to serialize this bitmap
+    ///
+    /// This does not include any additional padding which may be required to align the treemap
+    fn get_serialized_size_in_bytes(treemap: &Treemap) -> usize;
 }
 
-impl Serializer for Treemap {}
+pub trait Deserializer {
+    fn try_deserialize(buffer: &[u8]) -> Option<Treemap>;
+}
 
-impl NativeSerializer for Treemap {
-    type Item = Treemap;
+fn serialize_impl<'a, S>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8]
+where
+    S: crate::bitmap::Serializer,
+{
+    let start_idx = dst.len();
+    let map_len = u64::try_from(treemap.map.len()).unwrap();
+    dst.extend_from_slice(&map_len.to_ne_bytes());
 
-    fn serialize(&self) -> Result<Vec<u8>> {
-        let mut buffer = vec![];
-        buffer.write_u64::<NativeEndian>(self.map.len() as u64)?;
+    treemap.map.iter().for_each(|(&key, bitmap)| {
+        dst.extend_from_slice(&key.to_ne_bytes());
+        let prev_len = dst.len();
+        let serialized_slice = bitmap.serialize_into::<S>(dst);
+        let serialized_len = serialized_slice.len();
+        let serialized_range = serialized_slice.as_ptr_range();
+        // Serialization should only append the data, no padding can be allowed for this implementation
+        debug_assert_eq!(prev_len + serialized_len, dst.len());
+        debug_assert_eq!(serialized_range.end, dst.as_ptr_range().end);
+    });
+    &dst[start_idx..]
+}
 
-        for (index, bitmap) in &self.map {
-            buffer.write_u32::<NativeEndian>(*index)?;
-            let bitmap_buffer = bitmap.serialize::<Portable>();
-            buffer.extend(bitmap_buffer);
-        }
+fn size_in_bytes_impl<S>(treemap: &Treemap) -> usize
+where
+    S: crate::bitmap::Serializer,
+{
+    let overhead = size_of::<u64>() + treemap.map.len() * size_of::<u32>();
+    let total_sizes = treemap
+        .map
+        .values()
+        .map(|b| b.get_serialized_size_in_bytes::<S>())
+        .sum::<usize>();
+    overhead + total_sizes
+}
 
-        Ok(buffer)
+fn deserialize_impl<S>(mut buffer: &[u8]) -> Option<Treemap>
+where
+    S: crate::bitmap::Serializer + crate::bitmap::Deserializer,
+{
+    let map_len = buffer.read_u64::<NativeEndian>().ok()?;
+    let mut map = BTreeMap::new();
+    for _ in 0..map_len {
+        let key = buffer.read_u32::<NativeEndian>().ok()?;
+        let bitmap = Bitmap::try_deserialize::<S>(buffer)?;
+        buffer = &buffer[bitmap.get_serialized_size_in_bytes::<S>()..];
+        map.insert(key, bitmap);
+    }
+    Some(Treemap { map })
+}
+
+impl Serializer for Portable {
+    /// Serializes a Treemap to a slice of bytes in portable format.
+    /// See [`Treemap::serialize_into`] for examples.
+    fn serialize_into<'a>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8] {
+        serialize_impl::<Self>(treemap, dst)
     }
 
-    fn deserialize(buffer: &[u8]) -> Result<Self> {
-        let mut cursor = Cursor::new(&buffer);
-        let mut treemap = Treemap::new();
-        let bitmap_count = cursor.read_u64::<NativeEndian>()?;
+    /// Computes the serialized size in bytes of the Treemap in portable format.
+    /// See [`Treemap::get_size_in_bytes`] for examples.
+    fn get_serialized_size_in_bytes(treemap: &Treemap) -> usize {
+        size_in_bytes_impl::<Self>(treemap)
+    }
+}
 
+impl Deserializer for Portable {
+    fn try_deserialize(buffer: &[u8]) -> Option<Treemap> {
+        deserialize_impl::<Self>(buffer)
+    }
+}
+
+impl Serializer for Native {
+    /// Serializes a Treemap to a slice of bytes in native format.
+    /// See [`Treemap::serialize_into`] for examples.
+    fn serialize_into<'a>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8] {
+        serialize_impl::<Self>(treemap, dst)
+    }
+
+    /// Computes the serialized size in bytes of the Treemap in native format.
+    /// See [`Treemap::get_size_in_bytes`] for examples.
+    fn get_serialized_size_in_bytes(treemap: &Treemap) -> usize {
+        size_in_bytes_impl::<Self>(treemap)
+    }
+}
+
+impl Deserializer for Native {
+    fn try_deserialize(buffer: &[u8]) -> Option<Treemap> {
+        deserialize_impl::<Self>(buffer)
+    }
+}
+
+impl Serializer for Frozen {
+    /// Serializes a Treemap to a slice of bytes in frozen format.
+    /// See [`Treemap::serialize_into`] for examples.
+    fn serialize_into<'a>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8] {
+        const METADATA_SIZE: usize = size_of::<usize>() + size_of::<u32>();
+
+        let len = Self::get_serialized_size_in_bytes(treemap);
+        let mut offset = dst.len();
+        if dst.capacity() < dst.len() + len
+            || (dst.as_ptr() as usize + offset) % Self::REQUIRED_ALIGNMENT != 0
+        {
+            // Need to be able to add up to 31 extra bytes to align to 32 bytes
+            dst.reserve(len.checked_add(Self::REQUIRED_ALIGNMENT - 1).unwrap());
+            let extra_offset = match (dst.as_ptr() as usize + offset) % Self::REQUIRED_ALIGNMENT {
+                0 => 0,
+                r => Self::REQUIRED_ALIGNMENT - r,
+            };
+            offset = offset.checked_add(extra_offset).unwrap();
+            // we must initialize up to offset
+            dst.resize(offset, 0);
+        }
+        let total_len = offset.checked_add(len).unwrap();
+        debug_assert!(dst.capacity() >= total_len);
+
+        let map_size = u64::try_from(treemap.map.len()).unwrap();
+        dst.extend_from_slice(&map_size.to_be_bytes());
+
+        treemap.map.iter().for_each(|(&key, bitmap)| {
+            let extra_padding = match (dst.as_ptr_range().end as usize + METADATA_SIZE)
+                % Self::REQUIRED_ALIGNMENT
+            {
+                0 => 0,
+                r => Self::REQUIRED_ALIGNMENT - r,
+            };
+            dst.resize(dst.len() + extra_padding, 0);
+
+            let frozen_size_in_bytes: usize = bitmap.get_serialized_size_in_bytes::<Self>();
+            dst.extend_from_slice(&frozen_size_in_bytes.to_ne_bytes());
+            dst.extend_from_slice(&key.to_ne_bytes());
+
+            let before_bitmap_serialize = dst.as_ptr_range().end;
+            let serialized_slice = bitmap.serialize_into::<Self>(dst);
+            // We pre-calculated padding, so there should be no padding added
+            debug_assert_eq!(before_bitmap_serialize, serialized_slice.as_ptr());
+            debug_assert_eq!(serialized_slice.as_ptr_range().end, dst.as_ptr_range().end);
+        });
+
+        &dst[offset..]
+    }
+
+    /// Computes the serialized size in bytes of the Treemap in frozen format.
+    /// See [`Treemap::get_size_in_bytes`] for examples.
+    fn get_serialized_size_in_bytes(treemap: &Treemap) -> usize {
+        // Yes, the frozen format changes based on the size of usize
+        const METADATA_SIZE: usize = size_of::<usize>() + size_of::<u32>();
+
+        let mut result = size_of::<u64>();
+        for bitmap in treemap.map.values() {
+            // pad to 32 bytes minus the metadata size
+            result += METADATA_SIZE;
+            result += match result % 32 {
+                0 => 0,
+                r => 32 - r,
+            };
+            result += bitmap.get_serialized_size_in_bytes::<Self>();
+        }
+        result
+    }
+}
+
+impl Serializer for JvmLegacy {
+    fn serialize_into<'a>(treemap: &Treemap, dst: &'a mut Vec<u8>) -> &'a [u8] {
+        let start_idx = dst.len();
+        // Push a boolean false indicating that the values are not signed
+        dst.write_u8(0).unwrap();
+
+        let bitmap_count: u32 = treemap.map.len().try_into().unwrap();
+        dst.write_u32::<BigEndian>(bitmap_count).unwrap();
+        treemap.map.iter().for_each(|(&key, bitmap)| {
+            dst.write_u32::<BigEndian>(key).unwrap();
+            bitmap.serialize_into::<Portable>(dst);
+        });
+
+        &dst[start_idx..]
+    }
+
+    fn get_serialized_size_in_bytes(treemap: &Treemap) -> usize {
+        let overhead = size_of::<u8>() + size_of::<u32>() + size_of::<u32>() * treemap.map.len();
+        let total_sizes = treemap
+            .map
+            .values()
+            .map(|b| b.get_serialized_size_in_bytes::<Portable>())
+            .sum::<usize>();
+        overhead + total_sizes
+    }
+}
+
+impl Deserializer for JvmLegacy {
+    fn try_deserialize(mut buffer: &[u8]) -> Option<Treemap> {
+        // Ignored, we assume that the values are not signed
+        let _is_signed = buffer.read_u8().ok()?;
+
+        let bitmap_count = buffer.read_u32::<BigEndian>().ok()?;
+        let mut map = BTreeMap::new();
         for _ in 0..bitmap_count {
-            let index = cursor.read_u32::<NativeEndian>()?;
-            let bitmap = Bitmap::deserialize::<Portable>(&buffer[cursor.position() as usize..]);
-            cursor.seek(SeekFrom::Current(
-                bitmap.get_serialized_size_in_bytes::<Portable>() as i64,
-            ))?;
-            treemap.map.insert(index, bitmap);
+            let key = buffer.read_u32::<BigEndian>().ok()?;
+            let bitmap = Bitmap::try_deserialize::<Portable>(buffer)?;
+            buffer = &buffer[bitmap.get_serialized_size_in_bytes::<Portable>()..];
+            map.insert(key, bitmap);
         }
 
-        Ok(treemap)
-    }
-
-    /// How many bytes are required to serialize this bitmap with
-    /// NativeSerializer
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use croaring::Treemap;
-    /// use croaring::treemap::NativeSerializer;
-    ///
-    /// let mut treemap = Treemap::new();
-    ///
-    /// for i in 100..1000 {
-    ///   treemap.add(i);
-    /// }
-    ///
-    /// treemap.add(std::u32::MAX as u64);
-    /// treemap.add(std::u64::MAX);
-    ///
-    /// assert_eq!(treemap.get_serialized_size_in_bytes(), 1860);
-    /// ```
-    fn get_serialized_size_in_bytes(&self) -> usize {
-        self.map.iter().fold(
-            size_of::<u64>() + self.map.len() * size_of::<u32>(),
-            |sum, (_, bitmap)| sum + bitmap.get_serialized_size_in_bytes::<Portable>(),
-        )
-    }
-}
-
-/// croaring::Treemap serializer that is compatible with JVM version of Treemap
-/// found in RoaringBitmap Java implementation at:
-/// https://github.com/RoaringBitmap/RoaringBitmap/blob/master/roaringbitmap/src/main/java/org/roaringbitmap/longlong/Roaring64NavigableMap.java
-pub trait JvmSerializer: Serializer {
-    type Item;
-
-    fn serialize(&self) -> Result<Vec<u8>>;
-    fn deserialize(buffer: &[u8]) -> Result<Self::Item>;
-    fn get_serialized_size_in_bytes(&self) -> usize;
-}
-
-impl JvmSerializer for Treemap {
-    type Item = Treemap;
-
-    fn serialize(&self) -> Result<Vec<u8>> {
-        let mut buffer = vec![];
-        buffer.write_u8(0)?;
-        buffer.write_u32::<BigEndian>(self.map.len() as u32)?;
-
-        for (index, bitmap) in &self.map {
-            buffer.write_u32::<BigEndian>(*index)?;
-            let bitmap_buffer = bitmap.serialize::<Portable>();
-            buffer.extend(bitmap_buffer);
-        }
-
-        Ok(buffer)
-    }
-
-    fn deserialize(buffer: &[u8]) -> Result<Self::Item> {
-        let mut cursor = Cursor::new(&buffer);
-        cursor.read_u8()?; // read and discard boolean indicator
-
-        let mut treemap = Treemap::new();
-        let bitmap_count = cursor.read_u32::<BigEndian>()?;
-
-        for _ in 0..bitmap_count {
-            let index = cursor.read_u32::<BigEndian>()?;
-            let bitmap = Bitmap::deserialize::<Portable>(&buffer[cursor.position() as usize..]);
-            cursor.seek(SeekFrom::Current(
-                bitmap.get_serialized_size_in_bytes::<Portable>() as i64,
-            ))?;
-            treemap.map.insert(index, bitmap);
-        }
-
-        Ok(treemap)
-    }
-
-    /// How many bytes are required to serialize this bitmap with
-    /// JvmSerializer
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use croaring::Treemap;
-    /// use croaring::treemap::JvmSerializer;
-    ///
-    /// let mut treemap = Treemap::new();
-    ///
-    /// for i in 100..1000 {
-    ///   treemap.add(i);
-    /// }
-    ///
-    /// treemap.add(std::u32::MAX as u64);
-    /// treemap.add(std::u64::MAX);
-    ///
-    /// assert_eq!(treemap.get_serialized_size_in_bytes(), 1857);
-    /// ```
-    fn get_serialized_size_in_bytes(&self) -> usize {
-        self.map.iter().fold(
-            size_of::<u8>() + size_of::<u32>() + self.map.len() * size_of::<u32>(),
-            |sum, (_, bitmap)| sum + bitmap.get_serialized_size_in_bytes::<Portable>(),
-        )
+        Some(Treemap { map })
     }
 }


### PR DESCRIPTION
See #108 

Makes the changes from #106 for treemap.

This also adds some more doc comments to serialization types/functions, and does some misc clippy fixes for treemap functions.