### PR TITLE
Export TreemapIterator

### DIFF
--- a/croaring/src/treemap/mod.rs
+++ b/croaring/src/treemap/mod.rs
@@ -35,3 +35,4 @@ pub struct Treemap {
 }
 
 pub use crate::treemap::serialization::{JvmSerializer, NativeSerializer};
+pub use self::iter::TreemapIterator;


### PR DESCRIPTION
This type wasn't exported. I don't think this was intentional.