### PR TITLE
Don't re-export BitmapIterator at the top level

### DIFF
--- a/croaring/src/lib.rs
+++ b/croaring/src/lib.rs
@@ -1,3 +1,8 @@
+#![deny(missing_docs)]
+//! Rust wrapper for `CRoaring` (a C/C++ implementation at <https://github.com/RoaringBitmap/CRoaring>)
+//!
+//! Provides Compressed Bitmaps, which act like a set of integers in an efficient way.
+
 pub mod bitmap;
 pub mod bitset;
 pub mod treemap;

--- a/croaring/src/lib.rs
+++ b/croaring/src/lib.rs
@@ -7,7 +7,6 @@ mod serialization;
 pub use serialization::*;
 
 pub use bitmap::Bitmap;
-pub use bitmap::BitmapIterator;
 pub use bitset::Bitset;
 pub use treemap::Treemap;
 

--- a/croaring/src/treemap/iter.rs
+++ b/croaring/src/treemap/iter.rs
@@ -30,6 +30,9 @@ type InnerIter<'a> = iter::FlatMap<
     fn((&'a u32, &'a Bitmap)) -> To64Iter<'a>,
 >;
 
+/// Iterator over values stored in the treemap
+///
+/// Values are ordered in ascending order
 pub struct TreemapIterator<'a> {
     iter: InnerIter<'a>,
 }

--- a/croaring/src/treemap/iter.rs
+++ b/croaring/src/treemap/iter.rs
@@ -1,5 +1,6 @@
 use super::util;
-use super::{Bitmap, BitmapIterator, Treemap};
+use crate::bitmap::BitmapIterator;
+use crate::{Bitmap, Treemap};
 use std::collections::btree_map;
 use std::iter::{self, FromIterator};
 

--- a/croaring/src/treemap/mod.rs
+++ b/croaring/src/treemap/mod.rs
@@ -31,7 +31,11 @@ mod util;
 pub use iter::TreemapIterator;
 pub use serialization::{Deserializer, Serializer};
 
+/// A RoaringBitmap-based structure that supports 64bit unsigned integer values
+///
+/// Implemented as a [`BTreeMap`] of [`Bitmap`]s.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Treemap {
+    /// The underlying map of bitmaps
     pub map: BTreeMap<u32, Bitmap>,
 }

--- a/croaring/src/treemap/mod.rs
+++ b/croaring/src/treemap/mod.rs
@@ -20,7 +20,6 @@
 //! assert_eq!(treemap.cardinality(), 3);
 //! ```
 use crate::Bitmap;
-use crate::BitmapIterator;
 use std::collections::BTreeMap;
 
 mod imp;


### PR DESCRIPTION
Instead, it can still be accessed through `croaring::bitmap::BitmapIterator`, and often iterator types are exported through a submodule even when the type they iterate over is re-exported at a higher level.

Additionally, enforce doc comments everywhere, and add the few remaining missing docs.

@saulius, I think this is the last change I had in mind before `1.0`