### PR TITLE
Add a CI job to check the minimal version constraints of direct dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,4 +73,4 @@ jobs:
 
     - name: Minimal versions
       if: matrix.rust == 'nightly'
-      run: cargo +${{ matrix.rust }} -Zdirect-minimal-versions build
+      run: cargo +${{ matrix.rust }} -Zdirect-minimal-versions test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,3 +70,7 @@ jobs:
     - name: Benchmark
       if: matrix.rust == 'nightly'
       run: cargo +${{ matrix.rust }} bench
+
+    - name: Minimal versions
+      if: matrix.rust == 'nightly'
+      run: cargo +${{ matrix.rust }} -Zdirect-minimal-versions build

--- a/croaring/Cargo.toml
+++ b/croaring/Cargo.toml
@@ -23,7 +23,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 [dependencies]
 ffi = { package = "croaring-sys", path = "../croaring-sys", version = "1.0.0" }
-byteorder = "1"
+byteorder = "1.4.3"
 
 [[bench]]
 name = "benches"

--- a/croaring/Cargo.toml
+++ b/croaring/Cargo.toml
@@ -22,7 +22,7 @@ roaring = "0.10"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [dependencies]
-ffi = { package = "croaring-sys", path = "../croaring-sys", version = "1.0.0" }
+ffi = { package = "croaring-sys", path = "../croaring-sys", version = "1.1.0" }
 byteorder = "1.4.3"
 
 [[bench]]


### PR DESCRIPTION
~~I'm seeing a few issues that I will fix in a minute, but I want to make sure this test would catch them in CI (if CI is allowed to run on my PR)~~ Ok that has to be approved, but it turns out CI as-is wouldn't have caught my issue anyway, but I'm including it here because it caught a different issue... keep reading for more explanation but I'm happy to take out whatever commits you'd like me to.

## What happened

I upgraded a project I work on that uses `croaring` to move off of the yanked version `1.0.0`. I did this by running `cargo update -p croaring`, forgetting that `croaring-sys` would need an update too (and also forgetting to pass `--aggressive`).

The project's build started failing with these errors:

```
   Compiling croaring v1.0.1
error[E0425]: cannot find function `roaring_bitmap_internal_validate` in crate `ffi`
    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/croaring-1.0.1/src/bitmap/imp.rs:1495:35
     |
1495 |         let valid = unsafe { ffi::roaring_bitmap_internal_validate(&self.bitmap, &mut error_str) };
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `ffi`

error[E0699]: cannot call a method on a raw pointer with an unknown pointee type
    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/croaring-1.0.1/src/bitmap/imp.rs:1499:26
     |
1499 |             if error_str.is_null() {
     |                          ^^^^^^^
```

So really, `croaring` v1.0.1 depends on at least v1.1.0 of `croaring-sys`, but `cargo update -p croaring` didn't take care of that because `croaring` specifies `croaring-sys version = "1.0.0"` so the existing `croaring-sys` v1.0.0 in my project's lockfile was compatible.

I've corrected this problem by updating the version specified in `croaring`'s Cargo.toml to be `croaring-sys version = "1.1.0"`.

I was hoping that building with [cargo's unstable minimal versions flag](https://doc.rust-lang.org/stable/cargo/reference/unstable.html#direct-minimal-versions) would prevent this from reoccurring in the future, but it looks like because of the `path` dependency for `croaring-sys` that's used when building in this repo, cargo uses whatever version is at the `path` and not the minimal version someone using the crates from crates.io would experience :( I'm going to make sure this issue was raised somewhere in the discussions of the cargo feature.

But when I ran with `cargo +nightly check -Zdirect-minimal-versions`, it did report a problem with `byteorder`, so I have included in this PR a commit to enable this check in CI and a commit to properly specify the minimum required `byteorder` version.

I'm happy to make any changes you'd like, please let me know!