### PR TITLE
bugfix: Treemap.andnot would not include items with no container on rhs

### DIFF
--- a/croaring/src/treemap/imp.rs
+++ b/croaring/src/treemap/imp.rs
@@ -938,9 +938,18 @@ impl Treemap {
         let mut treemap = Treemap::new();
 
         for (key, bitmap) in &self.map {
-            if let Some(other_bitmap) = other.map.get(key) {
-                treemap.map.insert(*key, bitmap.andnot(other_bitmap));
-            }
+            let sub_bitmap = match other.map.get(key) {
+                Some(other_bitmap) => {
+                    let sub_bitmap = bitmap.andnot(other_bitmap);
+                    if sub_bitmap.is_empty() {
+                        continue;
+                    }
+                    sub_bitmap
+                }
+                // x.andnot(empty) == x
+                None => bitmap.clone(),
+            };
+            treemap.map.insert(*key, sub_bitmap);
         }
 
         treemap

--- a/croaring/src/treemap/ops.rs
+++ b/croaring/src/treemap/ops.rs
@@ -472,7 +472,7 @@ impl<'a, 'b> Sub<&'a Treemap> for &'b Treemap {
     /// let mut treemap2 = Treemap::new();
     ///
     /// treemap2.add(25);
-    /// treemap1.add(u64::MAX);
+    /// treemap2.add(u64::MAX);
     ///
     /// let treemap3 = &treemap1 - &treemap2;
     ///

--- a/croaring/tests/lib.rs
+++ b/croaring/tests/lib.rs
@@ -169,6 +169,18 @@ fn test_treemap_deserialize_jvm() {
 }
 
 #[test]
+fn test_treemap_max_andnot_empty() {
+    let single_max = Treemap::of(&[std::u64::MAX]);
+    let empty = Treemap::new();
+    let diff = single_max.andnot(&empty);
+    assert_eq!(diff, single_max);
+
+    let mut diff = single_max.clone();
+    diff.andnot_inplace(&empty);
+    assert_eq!(diff, single_max);
+}
+
+#[test]
 fn treemap_run_optimized() {
     let mut initial = Bitmap::new();
     initial.add(1);


### PR DESCRIPTION
And add a test which validates the expected behavior. This also found a doc test which was accidentally incorrect.