### PR TITLE
Fix #148

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,11 @@ jobs:
       run: cargo +${{ matrix.rust }} test --no-default-features --features "${{ matrix.cargo_features }}"
 
     - name: Minimal versions
-      run: cargo minimal-versions test --detach-path-deps --direct --workspace
+      # cargo-minimal-versions won't detach the path deps if we're using dev dependencies
+      # so we won't catch the case where we compile but fail tests because of path dependencies
+      run: |
+        cargo +${{ matrix.rust }} minimal-versions check --detach-path-deps --direct --workspace
+        cargo +${{ matrix.rust }} minimal-versions test --direct --workspace
       if: matrix.rust == 'nightly' && matrix.cargo_features == 'default'
       
     - name: Updated versions

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,10 +53,6 @@ jobs:
     - name: Test
       run: cargo +${{ matrix.rust }} test --no-default-features --features "${{ matrix.cargo_features }}"
 
-    - name: Benchmark
-      run: cargo +${{ matrix.rust }} bench --no-default-features --features "${{ matrix.cargo_features }}"
-      if: matrix.rust == 'nightly' && matrix.cargo_features == 'default'
-
     - name: Minimal versions
       run: cargo minimal-versions test --detach-path-deps --direct --workspace
       if: matrix.rust == 'nightly' && matrix.cargo_features == 'default'
@@ -64,3 +60,7 @@ jobs:
     - name: Updated versions
       run: cargo update && cargo +${{ matrix.rust }} test --no-default-features --features "${{ matrix.cargo_features }}"
       if: matrix.rust == 'stable' && matrix.cargo_features == 'default'
+
+    - name: Benchmark
+      run: cargo +${{ matrix.rust }} bench --no-default-features --features "${{ matrix.cargo_features }}"
+      if: matrix.rust == 'nightly' && matrix.cargo_features == 'default'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,12 @@ jobs:
         targets: ${{ matrix.target }}
         components: 'rustfmt, clippy'
 
+    - name: Install cargo tools
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-hack,cargo-minimal-versions
+      if: matrix.rust == 'nightly' && matrix.cargo_features == 'default'
+
     - uses: actions/checkout@v4
 
     - name: Install LLVM
@@ -52,7 +58,7 @@ jobs:
       if: matrix.rust == 'nightly' && matrix.cargo_features == 'default'
 
     - name: Minimal versions
-      run: cargo +${{ matrix.rust }} -Zdirect-minimal-versions test --no-default-features --features "${{ matrix.cargo_features }}"
+      run: cargo minimal-versions test --detach-path-deps --direct --workspace
       if: matrix.rust == 'nightly' && matrix.cargo_features == 'default'
       
     - name: Updated versions

--- a/croaring-sys/Cargo.toml
+++ b/croaring-sys/Cargo.toml
@@ -20,4 +20,4 @@ doctest = false
 [dependencies]
 
 [build-dependencies]
-cc = "1"
+cc = "1.1"

--- a/croaring/Cargo.toml
+++ b/croaring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croaring"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 authors = ["croaring-rs developers"]
 license = "Apache-2.0"
@@ -25,7 +25,7 @@ roaring = "0.10"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [dependencies]
-ffi = { package = "croaring-sys", path = "../croaring-sys", version = "4.1.0" }
+ffi = { package = "croaring-sys", path = "../croaring-sys", version = "~4.1.1" }
 
 [[bench]]
 name = "benches"


### PR DESCRIPTION
We're getting hit by: https://github.com/tokio-rs/tokio/pull/4490 - `-Zdirect-minimal-versions` doesn't affect path dependencies.

Instead, use cargo-minimal-versions which handles this and some other edge cases with checking against minimal versions.

Currently expecting this to fail because of #148. Once we confirm this would catch such a problem from happening again, this PR will be updated to include a fix.

