### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "croaring"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "criterion",
  "croaring-sys",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "croaring-sys"
-version = "4.3.3"
+version = "4.3.4"
 dependencies = [
  "cc",
 ]

--- a/croaring-sys/CHANGELOG.md
+++ b/croaring-sys/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [4.3.4](https://github.com/RoaringBitmap/croaring-rs/compare/croaring-sys-v4.3.3...croaring-sys-v4.3.4) - 2025-06-01
+
+### Other
+- *(deps)* Bump cc from 1.2.15 to 1.2.17 (by @dependabot[bot]) - #175

--- a/croaring-sys/Cargo.toml
+++ b/croaring-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croaring-sys"
-version = "4.3.3"
+version = "4.3.4"
 edition = "2021"
 authors = ["croaring-rs developers"]
 license = "Apache-2.0"

--- a/croaring/CHANGELOG.md
+++ b/croaring/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1](https://github.com/RoaringBitmap/croaring-rs/compare/croaring-v2.3.0...croaring-v2.3.1) - 2025-06-01
+
+### Other
+- Correct return docs for run_optimize function (by @Dr-Emann) - #177
+
 ## [2.3.0](https://github.com/RoaringBitmap/croaring-rs/compare/croaring-v2.2.0...croaring-v2.3.0) - 2025-03-25
 
 ### Added

--- a/croaring/Cargo.toml
+++ b/croaring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croaring"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 authors = ["croaring-rs developers"]
 license = "Apache-2.0"
@@ -25,7 +25,7 @@ roaring = "0.10"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [dependencies]
-ffi = { package = "croaring-sys", path = "../croaring-sys", version = "4.3.0" }
+ffi = { package = "croaring-sys", path = "../croaring-sys", version = "4.3.4" }
 
 [[bench]]
 name = "benches"


### PR DESCRIPTION



## 🤖 New release

* `croaring-sys`: 4.3.3 -> 4.3.4 (✓ API compatible changes)
* `croaring`: 2.3.0 -> 2.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `croaring-sys`

<blockquote>

## [4.3.4](https://github.com/RoaringBitmap/croaring-rs/compare/croaring-sys-v4.3.3...croaring-sys-v4.3.4) - 2025-06-01

### Other
- *(deps)* Bump cc from 1.2.15 to 1.2.17 (by @dependabot[bot]) - #175
</blockquote>

## `croaring`

<blockquote>

## [2.3.1](https://github.com/RoaringBitmap/croaring-rs/compare/croaring-v2.3.0...croaring-v2.3.1) - 2025-06-01

### Other
- Correct return docs for run_optimize function (by @Dr-Emann) - #177
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).